### PR TITLE
Make `ContainerAwareVersionFactory` invocable

### DIFF
--- a/src/Factory/ContainerAwareVersionFactory.php
+++ b/src/Factory/ContainerAwareVersionFactory.php
@@ -23,6 +23,11 @@ final class ContainerAwareVersionFactory implements MigrationFactory
         $this->container = $container;
     }
 
+    public function __invoke(string $migrationClassName): AbstractMigration
+    {
+        return $this->createVersion($migrationClassName);
+    }
+
     public function createVersion(string $migrationClassName): AbstractMigration
     {
         $instance = $this->migrationFactory->createVersion($migrationClassName);


### PR DESCRIPTION
As calling Doctrine class expect `callable` we can try to workaround this with `__invoke()` method.