### PR TITLE
Feat: Add DoctrineMigrationsPathsAdderTrait

### DIFF
--- a/src/DependencyInjection/DoctrineMigrationsPathsAdderTrait.php
+++ b/src/DependencyInjection/DoctrineMigrationsPathsAdderTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SyliusLabs\DoctrineMigrationsExtraBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+
+trait DoctrineMigrationsPathsAdderTrait
+{
+    /**
+     * Add a doctrine migration path, by taking care of user config
+     * Paths is an array with migrations namespace as key, and migrations location as value:
+     * @example $paths = ['MyAwesomeBundle\Migrations' => '@MyAwesomeBundle/migration'];
+     *
+     * @param array<string, string> $paths
+     */
+    private function addDoctrineMigrationPaths(array $paths, ContainerBuilder $container): void
+    {
+        if (! \in_array(PrependExtensionInterface::class, \class_implements(static::class), true)) {
+            throw new \BadMethodCallException(sprintf('Doctrine migration path can be added only in a class that implement %s', PrependExtensionInterface::class));
+        }
+
+        if (!$container->hasExtension('doctrine_migrations')) {
+            // this should not happen because it's required by this bundle, but we add to check doctrine_migrations is well registered (in bundles.php)
+            throw new \DomainException('Please make sure that DoctrineMigrationBundle is registered');
+        }
+
+        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
+        $container->prependExtensionConfig('doctrine_migrations', [
+            'migrations_paths' => \array_merge(\array_pop($doctrineConfig)['migrations_paths'] ?? [], $paths),
+        ]);
+    }
+}

--- a/tests/DependencyInjection/DoctrineMigrationsPathsAdderTrait/DoctrineNotLoadedTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsPathsAdderTrait/DoctrineNotLoadedTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SyliusLabs\DoctrineMigrationsExtraBundle\DependencyInjection\DoctrineMigrationsPathsAdderTrait;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use SyliusLabs\DoctrineMigrationsExtraBundle\DependencyInjection\DoctrineMigrationsPathsAdderTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+
+final class DoctrineNotLoadedTest extends AbstractExtensionTestCase
+{
+    public function testItThrowAnExceptionWhenDoctrineIsNotRegisteredExtension(): void
+    {
+        self::expectException(\DomainException::class);
+        self::expectExceptionMessage('Please make sure that DoctrineMigrationBundle is registered');
+
+        $this->load();
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [new class() extends Extension implements PrependExtensionInterface {
+
+            use DoctrineMigrationsPathsAdderTrait;
+
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+                // do nothing
+            }
+
+            public function getAlias(): string
+            {
+                return 'testing';
+            }
+
+            public function prepend(ContainerBuilder $container): void
+            {
+                $this->addDoctrineMigrationPaths([], $container);
+            }
+        }];
+    }
+}

--- a/tests/DependencyInjection/DoctrineMigrationsPathsAdderTrait/InvalidExtensionClassTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsPathsAdderTrait/InvalidExtensionClassTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SyliusLabs\DoctrineMigrationsExtraBundle\DependencyInjection\DoctrineMigrationsPathsAdderTrait;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use SyliusLabs\DoctrineMigrationsExtraBundle\DependencyInjection\DoctrineMigrationsPathsAdderTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+final class InvalidExtensionClassTest extends AbstractExtensionTestCase
+{
+
+    public function testItThrowAnExceptionWhenNotImplementPrependExtension(): void
+    {
+        self::expectException(\BadMethodCallException::class);
+        self::expectExceptionMessage('Doctrine migration path can be added only in a class that implement Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface');
+
+        $this->load();
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [new class() extends Extension {
+
+            use DoctrineMigrationsPathsAdderTrait;
+
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+                $this->addDoctrineMigrationPaths([], $container);
+            }
+
+            public function getAlias(): string
+            {
+                return 'testing';
+            }
+        }];
+    }
+}

--- a/tests/DependencyInjection/DoctrineMigrationsPathsAdderTraitTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsPathsAdderTraitTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SyliusLabs\DoctrineMigrationsExtraBundle\DependencyInjection;
+
+use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use SyliusLabs\DoctrineMigrationsExtraBundle\DependencyInjection\DoctrineMigrationsPathsAdderTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+
+final class DoctrineMigrationsPathsAdderTraitTest extends AbstractExtensionTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setParameter('kernel.bundles_metadata', []);
+    }
+
+    public function testItAddPathToDoctrineConfiguration(): void
+    {
+        $this->load();
+
+        $doctrineConfig = $this->container->getExtensionConfig('doctrine_migrations');
+
+        self::assertArrayHasKey('migrations_paths', $doctrineConfig[0]);
+        self::assertCount(1, $doctrineConfig[0]['migrations_paths']);
+        self::assertArrayHasKey('MyAwesomeBundle\Migrations', $doctrineConfig[0]['migrations_paths']);
+    }
+
+    public function testItKeepPreviouslySettedPathInFirstPosition(): void
+    {
+        $this->container->prependExtensionConfig('doctrine_migrations', [
+            'migrations_paths' => [
+                'DoctrineMigrations' => '../migrations'
+            ],
+        ]);
+
+        $this->load();
+
+        $doctrineConfig = $this->container->getExtensionConfig('doctrine_migrations');
+        self::assertArrayHasKey('migrations_paths', $doctrineConfig[0]);
+        self::assertCount(2, $doctrineConfig[0]['migrations_paths']);
+
+        self::assertSame('DoctrineMigrations', array_key_first($doctrineConfig[0]['migrations_paths']));
+        self::assertSame('MyAwesomeBundle\Migrations', array_key_last($doctrineConfig[0]['migrations_paths']));
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new DoctrineMigrationsExtension(),
+            new class extends Extension implements PrependExtensionInterface {
+
+                use DoctrineMigrationsPathsAdderTrait;
+
+                public function load(array $configs, ContainerBuilder $container): void
+                {
+                    // do nothing
+                }
+
+                public function getAlias(): string
+                {
+                    return 'testing';
+                }
+
+                public function prepend(ContainerBuilder $container): void
+                {
+                    $this->addDoctrineMigrationPaths(
+                        ['MyAwesomeBundle\Migrations' => '../MyAwesomeBundle/migrations'],
+                        $container
+                    );
+                }
+            }
+        ];
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/11960
| License         | MIT

Hi :wave: 

I add the `DoctrineMigrationsPathsAdderTrait` to provide to plugins or bundles a simple way to register their migrations without alter user config and by this way, avoid to user having generated migrations in vendor.

Not sure for the trait naming, if you have better idea, I'm listening :wink: 
