### PR TITLE
Allow usage of `marcj/topsort:^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.3 || ^8.0",
         "doctrine/doctrine-migrations-bundle": "^3.0",
         "doctrine/migrations": "^3.0",
-        "marcj/topsort": "^1.1",
+        "marcj/topsort": "^1.1 || ^2.0",
         "symfony/framework-bundle": "^4.4 || ^5.2"
     },
     "require-dev": {


### PR DESCRIPTION
That version supports newest PHP 7 & 8.