### PR TITLE
Fix invokable to make sure container linter works

### DIFF
--- a/src/Comparator/TopologicalVersionComparator.php
+++ b/src/Comparator/TopologicalVersionComparator.php
@@ -24,6 +24,11 @@ final class TopologicalVersionComparator implements Comparator
         $this->defaultSorter = new AlphabeticalComparator();
         $this->map = new TopologicalMap($packages);
     }
+    
+    public function __invoke(Version $a, Version $b): int
+    {
+        return $this->compare($a, $b);
+    }
 
     public function compare(Version $a, Version $b): int
     {

--- a/src/Factory/ContainerAwareVersionFactory.php
+++ b/src/Factory/ContainerAwareVersionFactory.php
@@ -22,6 +22,11 @@ final class ContainerAwareVersionFactory implements MigrationFactory
         $this->migrationFactory = $migrationFactory;
         $this->container = $container;
     }
+    
+    public function __invoke(string $migrationClassName): AbstractMigration
+    {
+        return $this->createVersion($migrationClassName);
+    }
 
     public function createVersion(string $migrationClassName): AbstractMigration
     {

--- a/tests/Comparator/TopologicalVersionComparatorTest.php
+++ b/tests/Comparator/TopologicalVersionComparatorTest.php
@@ -78,6 +78,32 @@ final class TopologicalVersionComparatorTest extends TestCase
         );
     }
 
+    /** @test */
+    public function it_can_be_called_as_a_function_and_does_compare(): void
+    {
+        // don't do this in real life, bad practice, but for testing it is ok
+        // I want to use the existing test function and decided to create an anonymous class
+        // that decorates the TopologicalVersionComparator except that it calls it as invokable every time
+        // you call compare()
+        $comparatorThatInvokesInsteadOfCompares = new Class implements Comparator{
+            protected Comparator $inner;
+            public function __construct() {
+                $this->inner = new TopologicalVersionComparator([]);
+            }
+
+            public function compare(Version $a, Version $b): int
+            {
+                return $this->inner->__invoke($a, $b);
+            }
+        };
+
+        $this->assertSorting(
+            $comparatorThatInvokesInsteadOfCompares,
+            ['Abc', 'Def', 'Ghi'],
+            ['Def', 'Ghi', 'Abc']
+        );
+    }
+
     /**
      * @param string[] $expectedVersions
      * @param string[] $actualVersions

--- a/tests/Factory/ContainerAwareVersionFactoryTest.php
+++ b/tests/Factory/ContainerAwareVersionFactoryTest.php
@@ -59,4 +59,26 @@ final class ContainerAwareVersionFactoryTest extends TestCase
         Assert::assertInstanceOf(NotContainerAwareMigration::class, $migration);
         Assert::assertNull($migration->getContainer());
     }
+
+    /** @test */
+    public function it_can_be_called_as_a_function_and_does_create_version(): void
+    {
+        // Arrange
+        $decoratedFactory = $this->createMock(MigrationFactory::class);
+        $container = $this->createMock(ContainerInterface::class);
+
+        $factory = new ContainerAwareVersionFactory($decoratedFactory, $container);
+
+        $decoratedFactory->method('createVersion')->willReturn(new NotContainerAwareMigration(
+            $this->createMock(Connection::class),
+            $this->createMock(LoggerInterface::class)
+        ));
+
+        // Act
+        $migration = $factory->__invoke('Some\\Class');
+
+        // Assert
+        Assert::assertInstanceOf(NotContainerAwareMigration::class, $migration);
+        Assert::assertNull($migration->getContainer());
+    }
 }


### PR DESCRIPTION
Hey, I created this fix to make sure the container linter is able to lint it. These missing `__invoke` methods made the `lint:container` command fail.