### PR TITLE
Add PHP 8.4, 8.5 and Symfony 8 to CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
     test:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}"
 
@@ -23,14 +23,20 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["8.1", "8.2", "8.3"]
-                symfony: ["^5.4", "^6.4", "^7.0"]
+                php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
+                symfony: ["^5.4", "^6.4", "^7.4", "^8.0"]
                 exclude:
                     - php: "8.1"
-                      symfony: "^7.0"
+                      symfony: "^7.4"
+                    - php: "8.1"
+                      symfony: "^8.0"
+                    - php: "8.2"
+                      symfony: "^8.0"
+                    - php: "8.3"
+                      symfony: "^8.0"
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -40,10 +46,10 @@ jobs:
 
             -   name: Get Composer cache directory
                 id: composer-cache
-                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             -   name: Cache Composer
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
                     key: ${{ runner.os }}-php-${{ matrix.php }}-package-${{ matrix.package }}-composer-${{ hashFiles(format('src/Sylius/{0}/composer.json', matrix.package)) }}
@@ -68,9 +74,9 @@ jobs:
                 run: vendor/bin/phpunit
 
             -   name: Run Infection
-                if: ${{matrix.symfony == '^7.0' }}
+                if: ${{ matrix.symfony == '^7.4' || matrix.symfony == '^8.0' }}
                 run: phpdbg -qrr vendor/bin/infection --min-msi=82
 
             -   name: Run Infection
-                if: ${{matrix.symfony != '^7.0' }}
+                if: ${{ matrix.symfony != '^7.4' && matrix.symfony != '^8.0' }}
                 run: phpdbg -qrr vendor/bin/infection --min-msi=100


### PR DESCRIPTION
Add PHP 8.4, 8.5 and Symfony 7.4, 8.0 builds to CI matrix.