### PR TITLE
Allow services migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ doctrine_migrations:
 
 ## Usage
 
+### Service Migrations (Symfony 7+)
+
+To use migrations as services (allowing constructor dependency injection), register your migrations with the `doctrine_migrations.migration` tag:
+
+```yaml
+# config/services.yaml
+services:
+    App\Migrations\Version20260101:
+        tags: ['doctrine_migrations.migration']
+```
+
+The bundle's `ServiceLoaderMigrationFactory` will automatically resolve these services. If a migration is not registered as a service, it will fall back to the default behavior (including support for `ContainerAwareInterface` in older Symfony versions).
+
 ### In an application
 
 In order to define the topology of migrations, configure it in `config/packages/sylius_labs_doctrine_migrations_extra.yaml`:

--- a/src/Factory/ServiceLoaderMigrationFactory.php
+++ b/src/Factory/ServiceLoaderMigrationFactory.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace SyliusLabs\DoctrineMigrationsExtraBundle\Factory;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Version\MigrationFactory;
+use Psr\Container\ContainerInterface;
+
+final class ServiceLoaderMigrationFactory implements MigrationFactory
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ServiceLocator<AbstractMigration> $locator
+     */
+    public function __construct(
+        private MigrationFactory $fallbackFactory,
+        private ContainerInterface $locator,
+    ) {}
+
+    public function createVersion(string $migrationClassName): AbstractMigration
+    {
+        if ($this->locator->has($migrationClassName)) {
+            return $this->locator->get($migrationClassName);
+        }
+
+        return $this->fallbackFactory->createVersion($migrationClassName);
+    }
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Version\DbalMigrationFactory;
-use Psr\Log\LoggerInterface;
 use SyliusLabs\DoctrineMigrationsExtraBundle\Comparator\TopologicalVersionComparator;
 use SyliusLabs\DoctrineMigrationsExtraBundle\Factory\ContainerAwareVersionFactory;
+use SyliusLabs\DoctrineMigrationsExtraBundle\Factory\ServiceLoaderMigrationFactory;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\DependencyInjection\Reference;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_locator;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -25,6 +25,13 @@ return static function (ContainerConfigurator $container): void {
                     service('logger'),
                 ]),
             service('service_container'),
+        ]);
+
+    $services->set(ServiceLoaderMigrationFactory::class)
+        ->decorate('doctrine.migrations.migrations_factory')
+        ->args([
+            service('doctrine.migrations.migrations_factory.inner'),
+            tagged_locator('doctrine_migrations.migration'),
         ]);
 
     $services->set(TopologicalVersionComparator::class)

--- a/tests/Factory/ServiceLoaderMigrationFactoryTest.php
+++ b/tests/Factory/ServiceLoaderMigrationFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\SyliusLabs\DoctrineMigrationsExtraBundle\Factory;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Version\MigrationFactory;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use SyliusLabs\DoctrineMigrationsExtraBundle\Factory\ServiceLoaderMigrationFactory;
+
+final class ServiceLoaderMigrationFactoryTest extends TestCase
+{
+    /** @test */
+    public function migration_present_in_locator_is_returned(): void
+    {
+        // Arrange
+        $locator = $this->createMock(ContainerInterface::class);
+        $fallback = $this->createMock(MigrationFactory::class);
+        $migration = $this->createMock(AbstractMigration::class);
+
+        $locator->method('has')->with('Some\\Migration')->willReturn(true);
+        $locator->method('get')->with('Some\\Migration')->willReturn($migration);
+        $fallback->expects($this->never())->method('createVersion');
+
+        $factory = new ServiceLoaderMigrationFactory($fallback, $locator);
+
+        // Act
+        $result = $factory->createVersion('Some\\Migration');
+
+        // Assert
+        Assert::assertSame($migration, $result);
+    }
+
+    /** @test */
+    public function migration_missing_in_locator_is_delegated_to_fallback(): void
+    {
+        // Arrange
+        $locator = $this->createMock(ContainerInterface::class);
+        $fallback = $this->createMock(MigrationFactory::class);
+        $migration = $this->createMock(AbstractMigration::class);
+
+        $locator->method('has')->with('Some\\Migration')->willReturn(false);
+        $fallback->method('createVersion')->with('Some\\Migration')->willReturn($migration);
+
+        $factory = new ServiceLoaderMigrationFactory($fallback, $locator);
+
+        // Act
+        $result = $factory->createVersion('Some\\Migration');
+
+        // Assert
+        Assert::assertSame($migration, $result);
+    }
+}


### PR DESCRIPTION
Hi there :wave:  

I am migrating an old Sylius app from v1 to v2, upgrading also symfony to SF7.4. 

During upgrade, I noticed that my old migrations raised an exception as the ContainerAwareInterface does not longer exist. 

I tried to migrate migrations to services, enabling this in my doctrine_migration config

```
# config/packages/doctrine_migrations.yaml

doctrine_migrations:
    enable_service_migrations: true
```

It works well **BUT** it didn't see anymore any migration from sylius core and plugin. 

The Factory added in the PR will automatically retrieve migration as service if registered with tag `doctrine_migrations.migration`, and if not retrieve any, fallback to the current factory. 

It's allow to having some migration as service, and kept the whole migration discovery process from core/plugin working.

:warning: This doesn't require `enable_service_migrations` in your config. If you leave it enabled, Doctrine Migrations will ignore the factory override and use its default service provider instead, so no core/plugin migration will be visible.

